### PR TITLE
Improve CUDA upscale algorithm and add CMake support

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,3 +160,106 @@ python3 scripts/stitch.py --input upscaled/ --output masterpiece.jpg
 ---
 
 *Made with ❤️, 🧉, and a concerning amount of coffee.*  
+
+## 🧑💻 **Updated Installation Instructions**  
+
+### **1. M1 Mac Setup**  
+*(Because you’re too invested in the Apple ecosystem to quit now)*  
+```bash  
+# Install OpenCV (because we all need emotional support)  
+brew install opencv --with-teeny-tiny-screams  
+
+# Clone this repo like you’re stealing the Declaration of Independence  
+git clone https://github.com/bniladridas/HybridCompute.git  
+cd HybridCompute  
+```
+
+### **2. Compile the Preprocessor**  
+*(Where your Mac pretends to be useful)*  
+```bash  
+mkdir build && cd build  
+cmake .. -DCMAKE_BUILD_TYPE="FingersCrossed"  
+make -j4  # -j8 if you’re feeling spicy 🌶️  
+```
+
+### **3. Cloud GPU Setup**  
+*(Where you throw money at AWS)*  
+1. Launch a GPU instance.  
+2. Cry softly at the hourly cost.  
+3. Compile the CUDA code using the new CMakeLists.txt file:  
+```bash  
+cd cloud_gpu  
+mkdir build && cd build  
+cmake ..  
+make -j4  # Adjust based on your instance type  
+```
+
+## 🎮 **Updated Usage Instructions**  
+
+### **Local Preprocessing**  
+```bash  
+# Split image into tiles  
+./preprocess cat_meme.jpg tiles/  
+
+# Watch your Mac’s fan make airplane noises ✈️  
+```
+
+### **Cloud Upscaling**  
+```bash  
+# Send tiles to the cloud (and your wallet to the shadow realm)  
+./scripts/transfer_tiles.sh  
+
+# Run the CUDA code using the new CMakeLists.txt file  
+cd cloud_gpu/build  
+./upscaler  
+
+# Wait 3-5 business days for CUDA to work its magic  
+```
+
+### **Stitch the Final Image**  
+```bash  
+python3 scripts/stitch.py --input upscaled/ --output masterpiece.jpg  
+
+# Marvel at your creation. Cry if it’s blurry.  
+```
+*Made with ❤️, 🧉, and a concerning amount of coffee.*  
+
+---
+
+## 🧑💻 **Updated Installation Instructions**  
+
+### **1. M1 Mac Setup**  
+*(Because you’re too invested in the Apple ecosystem to quit now)*  
+```bash  
+# Install OpenCV (because we all need emotional support)  
+brew install opencv --with-teeny-tiny-screams  
+
+# Clone this repo like you’re stealing the Declaration of Independence  
+git clone https://github.com/bniladridas/HybridCompute.git  
+cd HybridCompute  
+```
+
+### **2. Compile the Preprocessor**  
+*(Where your Mac pretends to be useful)*  
+```bash  
+mkdir build && cd build  
+cmake .. -DCMAKE_BUILD_TYPE="FingersCrossed"  
+make -j4  # -j8 if you’re feeling spicy 🌶️  
+```
+
+### **3. Cloud GPU Setup**  
+*(Where you throw money at AWS)*  
+1. Launch a GPU instance.  
+2. Cry softly at the hourly cost.  
+3. Compile the CUDA code using CMake:  
+```bash  
+make -j4  # Adjust based on your instance's capabilities  
+```
+
+---
+
+## 🎮 **Updated Usage Instructions**  
+
+### **Local Preprocessing**  
+```bash  
+# Split image into tiles  

--- a/cloud_gpu/CMakeLists.txt
+++ b/cloud_gpu/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.10)
+project(HybridCompute)
+
+set(CUDAToolkit_ROOT /usr/local/cuda)  # Update this line with the correct path
+
+find_package(OpenCV REQUIRED)
+find_package(CUDAToolkit REQUIRED)
+
+include_directories(${OpenCV_INCLUDE_DIRS})
+include_directories(${CMAKE_SOURCE_DIR}/include)
+
+add_executable(preprocess src/preprocess.cpp)
+target_link_libraries(preprocess ${OpenCV_LIBS})
+
+add_executable(upscale cloud_gpu/upscale.cu)
+target_link_libraries(upscale ${OpenCV_LIBS} CUDA::cudart)

--- a/cloud_gpu/upscale.cu
+++ b/cloud_gpu/upscale.cu
@@ -2,25 +2,55 @@
 #include <iostream>
 #include <cuda_runtime.h>
 
+__device__ float cubicInterpolate(float p0, float p1, float p2, float p3, float t) {
+    return p1 + 0.5f * t * (p2 - p0 + t * (2.0f * p0 - 5.0f * p1 + 4.0f * p2 - p3 + t * (3.0f * (p1 - p2) + p3 - p0)));
+}
+
 __global__ void bicubicUpscaleKernel(uchar* input, uchar* output, int in_w, int in_h, int scale) {
     int x = blockIdx.x * blockDim.x + threadIdx.x;
     int y = blockIdx.y * blockDim.y + threadIdx.y;
 
     if (x >= in_w || y >= in_h) return;
 
-    // Simplified bicubic logic (replace with actual algorithm)
     for (int i = 0; i < scale; i++) {
         for (int j = 0; j < scale; j++) {
+            float gx = (float)x + (float)i / (float)scale;
+            float gy = (float)y + (float)j / (float)scale;
+
+            int gxi = (int)gx;
+            int gyi = (int)gy;
+
+            float c[4][4];
+            for (int m = -1; m <= 2; m++) {
+                for (int n = -1; n <= 2; n++) {
+                    int px = min(max(gxi + m, 0), in_w - 1);
+                    int py = min(max(gyi + n, 0), in_h - 1);
+                    c[m + 1][n + 1] = input[(py * in_w + px) * 3];
+                }
+            }
+
+            float col[4];
+            for (int m = 0; m < 4; m++) {
+                col[m] = cubicInterpolate(c[m][0], c[m][1], c[m][2], c[m][3], gx - gxi);
+            }
+
+            float value = cubicInterpolate(col[0], col[1], col[2], col[3], gy - gyi);
             int out_idx = ((y * scale + j) * (in_w * scale) + (x * scale + i)) * 3;
-            output[out_idx] = input[(y * in_w + x) * 3];        // R
-            output[out_idx + 1] = input[(y * in_w + x) * 3 + 1];// G
-            output[out_idx + 2] = input[(y * in_w + x) * 3 + 2];// B
+            output[out_idx] = min(max((int)value, 0), 255);
         }
     }
 }
 
+#define CUDA_CHECK(call) \
+    do { \
+        cudaError_t err = call; \
+        if (err != cudaSuccess) { \
+            std::cerr << "CUDA error in " << __FILE__ << " at line " << __LINE__ << ": " << cudaGetErrorString(err) << std::endl; \
+            return -1; \
+        } \
+    } while (0)
+
 int main() {
-    // Load input tile (replace with actual file I/O)
     cv::Mat input = cv::imread("input_tile.jpg");
     if (input.empty()) {
         std::cerr << "Error: Could not load image!" << std::endl;
@@ -29,7 +59,7 @@ int main() {
 
     int in_w = input.cols;
     int in_h = input.rows;
-    int scale = 2; // Example scale factor
+    int scale = 2;
     int out_w = in_w * scale;
     int out_h = in_h * scale;
 
@@ -39,19 +69,19 @@ int main() {
     size_t input_size = in_w * in_h * 3 * sizeof(uchar);
     size_t output_size = out_w * out_h * 3 * sizeof(uchar);
 
-    cudaMalloc(&d_input, input_size);
-    cudaMalloc(&d_output, output_size);
+    CUDA_CHECK(cudaMalloc(&d_input, input_size));
+    CUDA_CHECK(cudaMalloc(&d_output, output_size));
 
-    cudaMemcpy(d_input, input.data, input_size, cudaMemcpyHostToDevice);
+    CUDA_CHECK(cudaMemcpy(d_input, input.data, input_size, cudaMemcpyHostToDevice));
 
     dim3 blockDim(16, 16);
     dim3 gridDim((in_w + blockDim.x - 1) / blockDim.x, (in_h + blockDim.y - 1) / blockDim.y);
     bicubicUpscaleKernel<<<gridDim, blockDim>>>(d_input, d_output, in_w, in_h, scale);
 
-    cudaMemcpy(output.data, d_output, output_size, cudaMemcpyDeviceToHost);
+    CUDA_CHECK(cudaMemcpy(output.data, d_output, output_size, cudaMemcpyDeviceToHost));
 
-    cudaFree(d_input);
-    cudaFree(d_output);
+    CUDA_CHECK(cudaFree(d_input));
+    CUDA_CHECK(cudaFree(d_output));
 
     cv::imwrite("output_tile.jpg", output);
 


### PR DESCRIPTION
Improve the bicubic interpolation algorithm and add error handling in `cloud_gpu/upscale.cu`.

* **Bicubic Interpolation Algorithm**
  - Add `cubicInterpolate` function for cubic interpolation.
  - Implement bicubic interpolation logic in `bicubicUpscaleKernel`.
  - Replace simplified bicubic logic with actual algorithm.
  - Update output assignment to use interpolated values.

* **Error Handling**
  - Add `CUDA_CHECK` macro for error handling of CUDA API calls.
  - Replace direct CUDA API calls with `CUDA_CHECK` wrapped calls.

* **CMakeLists.txt**
  - Add CMakeLists.txt file to build CUDA code.
  - Include necessary CUDA and OpenCV libraries.
  - Define project and set CUDA toolkit path.
  - Find and include OpenCV and CUDA libraries.
  - Add executables for preprocess and upscale.

* **README.md**
  - Update installation instructions to include new CMakeLists.txt file.
  - Add section on how to run CUDA code using new CMakeLists.txt file.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/bniladridas/HybridCompute/pull/1?shareId=0657f9e2-cf47-425d-8fa7-7831f461dcde).